### PR TITLE
[Auth] Pre-signup 이메일 검증(OTP) 플로우 도입 (Option B, VerifyEmailToken 재사용)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ dbdata/
 mysql/
 *.pid
 *.sock
+
+# Ignore environment files
+.env
+

--- a/src/main/java/com/example/final_projects/controller/EmailOtpController.java
+++ b/src/main/java/com/example/final_projects/controller/EmailOtpController.java
@@ -1,0 +1,34 @@
+package com.example.final_projects.controller;
+
+import com.example.final_projects.dto.ApiResult;
+import com.example.final_projects.dto.auth.EmailOtpDtos;
+import com.example.final_projects.service.EmailOtpService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth/email/otp")
+public class EmailOtpController {
+    private final EmailOtpService emailOtpService;
+
+    public EmailOtpController(EmailOtpService emailOtpService) {
+        this.emailOtpService = emailOtpService;
+    }
+
+    /** OTP 발송 요청 */
+    @PostMapping("/request")
+    public ApiResult<Void> request(@Valid @RequestBody EmailOtpDtos.RequestOtpRequest req) {
+        emailOtpService.requestOtp(req);
+        return ApiResult.ok("인증 코드가 전송되었습니다.", null);
+    }
+
+    /** OTP 검증 → pre-signup 검증토큰 발급 */
+    @PostMapping("/verify")
+    public ApiResult<EmailOtpDtos.VerifyOtpResponse> verify(@Valid @RequestBody EmailOtpDtos.VerifyOtpRequest req) {
+        var resp = emailOtpService.verifyOtp(req);
+        return ApiResult.ok("인증 코드가 확인되었습니다.", resp);
+    }
+}

--- a/src/main/java/com/example/final_projects/dto/auth/EmailOtpDtos.java
+++ b/src/main/java/com/example/final_projects/dto/auth/EmailOtpDtos.java
@@ -1,0 +1,7 @@
+package com.example.final_projects.dto.auth;
+
+public class EmailOtpDtos {
+    public record RequestOtpRequest(String email) {}
+    public record VerifyOtpRequest(String email, String code) {}
+    public record VerifyOtpResponse(String verificationToken, long expiresInSeconds) {}
+}

--- a/src/main/java/com/example/final_projects/dto/auth/SignupRequest.java
+++ b/src/main/java/com/example/final_projects/dto/auth/SignupRequest.java
@@ -9,9 +9,10 @@ public class SignupRequest {
         @Email @NotBlank private String email;
         @NotBlank @Size(min=8,max=64) private String password;
         @NotBlank @Size(min=1,max=30) private String name; // or name
+        @NotBlank private String emailVerificationToken;
 
         public SignupRequest() {}
-        public SignupRequest(String e, String p, String n){ this.email=e; this.password=p; this.name=n; }
+        public SignupRequest(String e, String p, String n, String e1){ this.email=e; this.password=p; this.name=n; this.emailVerificationToken=e1; }
         // getters/setters
 
     public String getEmail() {
@@ -24,6 +25,14 @@ public class SignupRequest {
 
     public String getName() {
         return name;
+    }
+
+    public String getEmailVerificationToken() {
+        return emailVerificationToken;
+    }
+
+    public void setEmailVerificationToken(String emailVerificationToken) {
+        this.emailVerificationToken = emailVerificationToken;
     }
 }
 

--- a/src/main/java/com/example/final_projects/entity/EmailOtp.java
+++ b/src/main/java/com/example/final_projects/entity/EmailOtp.java
@@ -1,0 +1,106 @@
+package com.example.final_projects.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "email_otp",
+        indexes = {
+            @Index(name="idx_email_otp_email", columnList="email"),
+            @Index(name="idx_email_otp_expires", columnList="expires_at"),
+            @Index(name="idx_email_otp_pending", columnList="email, verified, expires_at")
+        })
+public class EmailOtp {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable=false, length=255)
+    private String email;
+
+    @Column(name="code_hash", nullable=false, length=255)
+    private String codeHash;
+
+    @Column(name="expires_at", nullable=false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable=false)
+    private boolean verified = false;
+
+    @Column(name="attempt_count", nullable=false)
+    private int attemptCount = 0;
+
+    @Column(name="last_sent_at", nullable=false)
+    private LocalDateTime lastSentAt;
+
+    @Column(name="resend_count", nullable=false)
+    private int resendCount = 0;
+
+    @Column(name="created_at", nullable=false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name="updated_at", nullable=false)
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PreUpdate public void onUpdate() {this.updatedAt = LocalDateTime.now();}
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getCodeHash() {
+        return codeHash;
+    }
+
+    public void setCodeHash(String codeHash) {
+        this.codeHash = codeHash;
+    }
+
+    public LocalDateTime getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(LocalDateTime expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public boolean isVerified() {
+        return verified;
+    }
+
+    public void setVerified(boolean verified) {
+        this.verified = verified;
+    }
+
+    public int getAttemptCount() {
+        return attemptCount;
+    }
+
+    public void setAttemptCount(int attemptCount) {
+        this.attemptCount = attemptCount;
+    }
+
+    public LocalDateTime getLastSentAt() {
+        return lastSentAt;
+    }
+
+    public void setLastSentAt(LocalDateTime lastSentAt) {
+        this.lastSentAt = lastSentAt;
+    }
+
+    public int getResendCount() {
+        return resendCount;
+    }
+
+    public void setResendCount(int resendCount) {
+        this.resendCount = resendCount;
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/src/main/java/com/example/final_projects/entity/VerifyEmailToken.java
+++ b/src/main/java/com/example/final_projects/entity/VerifyEmailToken.java
@@ -5,7 +5,8 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "email_verification_token")
+@Table(name = "email_verification_token",
+       uniqueConstraints = @UniqueConstraint(name="uq_evt_token", columnNames="token"))
 public class VerifyEmailToken {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -13,14 +14,20 @@ public class VerifyEmailToken {
     @Column(nullable = false, unique = true, length = 100)
     private String token;
 
-    @ManyToOne(fetch= FetchType.LAZY) @JoinColumn(name="user_id", nullable = false)
+    @ManyToOne(fetch= FetchType.LAZY) @JoinColumn(name="user_id", nullable = true)
     private User user;
+
+    @Column(length=255)
+    private String email;
 
     @Column(nullable=false)
     private LocalDateTime expiresAt;
 
     @Column(nullable=false)
     private boolean used = false;
+
+    @Column(nullable=false)
+    private boolean preSignup = true;
 
     @Column(name="created_at", nullable=false, updatable=false)
     private LocalDateTime createdAt;
@@ -49,12 +56,13 @@ public class VerifyEmailToken {
         return used;
     }
 
-    public VerifyEmailToken(Long id, String token, User user, LocalDateTime expiresAt, boolean used) {
+    public VerifyEmailToken(Long id, String token, User user, LocalDateTime expiresAt, boolean used, String email) {
         this.id = id;
         this.token = token;
         this.user = user;
         this.expiresAt = expiresAt;
         this.used = used;
+        this.email = email;
     }
 
     public void setToken(String token) {
@@ -71,5 +79,21 @@ public class VerifyEmailToken {
 
     public void setUsed(boolean used) {
         this.used = used;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public boolean isPreSignup() {
+        return preSignup;
+    }
+
+    public void setPreSignup(boolean preSignup) {
+        this.preSignup = preSignup;
     }
 }

--- a/src/main/java/com/example/final_projects/repository/EmailOtpRepository.java
+++ b/src/main/java/com/example/final_projects/repository/EmailOtpRepository.java
@@ -1,0 +1,25 @@
+package com.example.final_projects.repository;
+
+import com.example.final_projects.entity.EmailOtp;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface EmailOtpRepository extends JpaRepository<EmailOtp, Long>{
+
+    @Query("select e from EmailOtp e where e.email = :email order by e.id desc")
+    List<EmailOtp> findAllByEmailOrderByIdDesc(@Param("email") String email);
+
+    @Modifying
+    @Query("update EmailOtp e set e.attemptCount = e.attemptCount + 1 where e.id = :id")
+    int incrementAttempt(@Param("id") Long id);
+
+    //만료된 OTP 청소
+    @Modifying
+    @Query("delete from EmailOtp e where e.expiresAt < :now")
+    int deleteExpired(@Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/example/final_projects/repository/UserRepository.java
+++ b/src/main/java/com/example/final_projects/repository/UserRepository.java
@@ -2,12 +2,42 @@ package com.example.final_projects.repository;
 
 import com.example.final_projects.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
+
+    @Modifying
+    @Query("update User u set u.lastLoginAt = :ts where u.id = :id")
+    int updateLastLoginAt(@Param("id") Long userId, @Param("ts") LocalDateTime timestamp);
+
+    // (선택) 실패 카운트 +1
+    @Modifying
+    @Query("update User u set u.failCount = u.failCount + 1 where u.id = :id")
+    int incrementFailCount(@Param("id") Long userId);
+
+    // (선택) 실패 카운트 0으로
+    @Modifying
+    @Query("update User u set u.failCount = 0 where u.id = :id")
+    int resetFailCount(@Param("id") Long userId);
+
+    // (선택) 잠금/해제
+    @Modifying
+    @Query("update User u set u.locked = :locked, u.lockedAt = :lockedAt where u.id = :id")
+    int setLocked(@Param("id") Long userId,
+                  @Param("locked") boolean locked,
+                  @Param("lockedAt") LocalDateTime lockedAt);
+
+    // (선택) 상태 변경
+    @Modifying
+    @Query("update User u set u.status = :status where u.id = :id")
+    int updateStatus(@Param("id") Long userId, @Param("status") User.Status status);
 }

--- a/src/main/java/com/example/final_projects/repository/VerifyEmailTokenRepository.java
+++ b/src/main/java/com/example/final_projects/repository/VerifyEmailTokenRepository.java
@@ -2,11 +2,33 @@ package com.example.final_projects.repository;
 
 import com.example.final_projects.entity.VerifyEmailToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
 public interface VerifyEmailTokenRepository extends JpaRepository<VerifyEmailToken,Long> {
     Optional<VerifyEmailToken> findByToken(String token);
+
+    //가입 시 토큰 1회성 소진
+    @Modifying
+    @Query("""
+        update VerifyEmailToken t
+           set t.used =true
+         where t.token = :token and t.used = false                
+        """)
+    int markUsedByToken(@Param("token") String token);
+
+    //만료/사용된 pre-sign 토큰 캇
+    @Modifying
+    @Query("""
+        delete from VerifyEmailToken t
+        where t.preSignup = true
+        and(t.used = true or t.expiresAt < :now)
+    """)
+    int deleteOldPreSignupTokens(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/example/final_projects/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/final_projects/service/AuthServiceImpl.java
@@ -115,7 +115,7 @@ import java.util.UUID;
                     """.formatted(link);
             mailService.send(link, subject, body);
 
-            return new SignupResponse(user.getId(), "회원가입이 완료되었습니다. 이메일 인증 후 사용가능");
+            return new SignupResponse(user.getId(), "회원가입이 완료되었습니다. ");
         }
 
         /**

--- a/src/main/java/com/example/final_projects/service/EmailOtpService.java
+++ b/src/main/java/com/example/final_projects/service/EmailOtpService.java
@@ -1,0 +1,11 @@
+package com.example.final_projects.service;
+
+import com.example.final_projects.dto.auth.EmailOtpDtos.RequestOtpRequest;
+import com.example.final_projects.dto.auth.EmailOtpDtos.VerifyOtpResponse;
+import com.example.final_projects.dto.auth.EmailOtpDtos.VerifyOtpRequest;
+
+public interface EmailOtpService {
+    void requestOtp(RequestOtpRequest req);
+    VerifyOtpResponse verifyOtp(VerifyOtpRequest req);
+    void assertValidVerificationTokenForSignup(String email, String verificationToken);
+}

--- a/src/main/java/com/example/final_projects/service/EmailOtpServiceImpl.java
+++ b/src/main/java/com/example/final_projects/service/EmailOtpServiceImpl.java
@@ -1,0 +1,166 @@
+package com.example.final_projects.service;
+
+import com.example.final_projects.dto.auth.EmailOtpDtos.*;
+import com.example.final_projects.entity.EmailOtp;
+import com.example.final_projects.entity.VerifyEmailToken;
+import com.example.final_projects.repository.EmailOtpRepository;
+import com.example.final_projects.repository.VerifyEmailTokenRepository;
+import com.example.final_projects.support.MailService;
+import com.example.final_projects.support.OtpCrypto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+@Service
+@Transactional
+public class EmailOtpServiceImpl implements EmailOtpService{
+
+    private final EmailOtpRepository otpRepo;
+    private final VerifyEmailTokenRepository tokenRepo;
+    private final OtpCrypto otpCrypto;
+    private final MailService mailService;
+
+    private final String pepper;
+    private final int codeLength;
+    private final int ttlSeconds;
+    private final int tokenTtlSeconds;
+    private final int resendMinSeconds;
+    private final int maxResendPerHour;
+    private final int maxAttempts;
+
+    private final Random rng = new SecureRandom();
+
+    public EmailOtpServiceImpl(EmailOtpRepository otpRepo,
+                               VerifyEmailTokenRepository tokenRepo,
+                               OtpCrypto otpCrypto,
+                               MailService mailService,
+                               @Value("${security.otp.pepper}") String pepper,
+                               @Value("${security.otp.code-length:6}") int codeLength,
+                               @Value("${security.otp.ttl-seconds:300}") int ttlSeconds,
+                               @Value("${security.otp.token-ttl-seconds:600}") int tokenTtlSeconds,
+                               @Value("${security.otp.resend-min-seconds:60}") int resendMinSeconds,
+                               @Value("${security.otp.max-resend-per-hour:5}") int maxResendPerHour,
+                               @Value("${security.otp.max-attempts:5}") int maxAttempts) {
+        this.otpRepo = otpRepo;
+        this.tokenRepo = tokenRepo;
+        this.otpCrypto = otpCrypto;
+        this.mailService = mailService;
+        this.pepper = pepper;
+        this.codeLength = codeLength;
+        this.ttlSeconds = ttlSeconds;
+        this.tokenTtlSeconds = tokenTtlSeconds;
+        this.resendMinSeconds = resendMinSeconds;
+        this.maxResendPerHour = maxResendPerHour;
+        this.maxAttempts = maxAttempts;
+    }
+
+    @Override
+    public void requestOtp(RequestOtpRequest req){
+        String email = norm(req.email());
+        LocalDateTime now = LocalDateTime.now();
+
+        List<EmailOtp> hist = otpRepo.findAllByEmailOrderByIdDesc(email);
+        EmailOtp latest = hist.isEmpty() ? null : hist.get(0);
+
+        if (latest != null) {
+            long sec = Duration.between(latest.getLastSentAt(), now).getSeconds();
+            if (sec < resendMinSeconds) {
+                throw new IllegalArgumentException("재발송은 " + (resendMinSeconds - sec) + "초 후에 가능합니다.");
+            }
+            if (latest.getResendCount() >= maxResendPerHour &&
+                    Duration.between(latest.getLastSentAt(), now).toHours() < 1) {
+                throw new IllegalArgumentException("재발송 한도를 초과했습니다. 잠시 후 다시 시도하세요.");
+            }
+        }
+
+        String code = genNumeric(codeLength);                 // 예: "493201"
+        String hash = otpCrypto.sha256WithPepper(code, pepper);
+
+        EmailOtp row = new EmailOtp();
+        row.setEmail(email);
+        row.setCodeHash(hash);
+        row.setExpiresAt(now.plusSeconds(ttlSeconds));
+        row.setVerified(false);
+        row.setAttemptCount(0);
+        row.setLastSentAt(now);
+        row.setResendCount((latest != null && Duration.between(latest.getLastSentAt(), now).toHours() < 1)
+                ? latest.getResendCount() + 1 : 0);
+
+        otpRepo.save(row);
+
+        // 실제 메일 전송 (템플릿/제목은 프로젝트 표준에 맞춰 조정)
+        mailService.send(
+                email,
+                "[Jober] 이메일 인증 코드",
+                "아래 6자리 코드를 5분 내에 입력하세요: " + code
+        );}
+    @Override
+    public VerifyOtpResponse verifyOtp(VerifyOtpRequest req){
+        String email = norm(req.email());
+        String code = req.code().trim();
+        LocalDateTime now = LocalDateTime.now();
+
+        EmailOtp candidate = otpRepo.findAllByEmailOrderByIdDesc(email).stream()
+                .filter(e -> !e.isVerified() && e.getExpiresAt().isAfter(now))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("유효한 OTP가 없습니다. 다시 발송해 주세요."));
+
+        if (candidate.getAttemptCount() >= maxAttempts) {
+            throw new IllegalArgumentException("시도 한도를 초과했습니다. OTP를 재발송해 주세요.");
+        }
+        otpRepo.incrementAttempt(candidate.getId());
+
+        // 해시 비교(상수시간 비교)
+        if (!otpCrypto.verify(code, candidate.getCodeHash(), pepper)) {
+            throw new IllegalArgumentException("OTP 코드가 올바르지 않습니다.");
+        }
+
+        // ✅ 핵심: pre-signup 검증토큰을 기존 테이블(VerifyEmailToken)에 INSERT
+        String vtoken = UUID.randomUUID().toString();
+        LocalDateTime vexp = now.plusSeconds(tokenTtlSeconds);
+
+        VerifyEmailToken vt = new VerifyEmailToken();
+        vt.setToken(vtoken);
+        vt.setUser(null);          // 회원가입 전이라 NULL
+        // 아래 두 줄을 위해 VerifyEmailToken 엔티티에 setter/getter가 있어야 함
+        vt.setEmail(email);        // ← 엔티티에 setEmail(String) 필요
+        vt.setPreSignup(true);     // ← 엔티티에 setPreSignup(boolean) 필요
+        vt.setExpiresAt(vexp);
+        vt.setUsed(false);
+        tokenRepo.save(vt);
+
+        // OTP 레코드 표시(선택)
+        candidate.setVerified(true);
+
+        long expiresIn = Duration.between(now, vexp).getSeconds();
+        return new VerifyOtpResponse(vtoken, expiresIn);}
+    @Override
+    public void assertValidVerificationTokenForSignup(String email, String verificationToken){
+        String normEmail = norm(email);
+        VerifyEmailToken t = tokenRepo.findByToken(verificationToken)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 이메일 검증 토큰입니다."));
+
+        // 아래 접근자들(getEmail/isPreSignup 등)이 엔티티에 구현되어 있어야 함
+        if (t.isUsed()) throw new IllegalArgumentException("이미 사용된 검증 토큰입니다.");
+        if (!t.isPreSignup()) throw new IllegalArgumentException("가입 전 검증용 토큰이 아닙니다.");
+        if (t.getExpiresAt() == null || t.getExpiresAt().isBefore(LocalDateTime.now()))
+            throw new IllegalArgumentException("검증 토큰이 만료되었습니다.");
+        if (t.getEmail() == null || !t.getEmail().equalsIgnoreCase(normEmail))
+            throw new IllegalArgumentException("이메일과 검증 토큰이 일치하지 않습니다.");
+    }
+
+    private String norm(String email){ return email.trim().toLowerCase(); }
+    private String genNumeric(int n){
+        StringBuilder sb = new StringBuilder(n);
+        for (int i = 0; i < n; i++) sb.append(rng.nextInt(10));
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/com/example/final_projects/support/OtpCrypto.java
+++ b/src/main/java/com/example/final_projects/support/OtpCrypto.java
@@ -1,0 +1,38 @@
+package com.example.final_projects.support;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+
+@Component
+public class OtpCrypto {
+
+    public String sha256WithPepper(String value, String pepper){
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(pepper.getBytes(StandardCharsets.UTF_8));
+            byte[] digest = md.digest(value.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(digest);
+        } catch(Exception e){
+            throw new IllegalStateException("OTP hashing error", e);
+        }
+    }
+
+    public boolean slowEquals(String a, String b){
+        if(a == null || b == null) return false;
+        byte[] x = a.getBytes(StandardCharsets.UTF_8);
+        byte[] y = b.getBytes(StandardCharsets.UTF_8);
+        if(x.length != y.length) return false;
+        int r= 0;
+        for (int i = 0; i < x.length; i++) r |= (x[i] ^ y[i]);
+        return r == 0;
+    }
+
+    // 평문 OTP와 해시의 일치 여부 검증
+    public boolean verify(String plainOtp, String storedHash, String pepper) {
+        String inputHash = sha256WithPepper(plainOtp, pepper);
+        return slowEquals(inputHash, storedHash);
+    }
+}

--- a/src/main/java/com/example/final_projects/support/OtpGenerator.java
+++ b/src/main/java/com/example/final_projects/support/OtpGenerator.java
@@ -1,0 +1,16 @@
+package com.example.final_projects.support;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+@Component
+public class OtpGenerator {
+    private final SecureRandom rng = new SecureRandom();
+
+    public String numeric(int n){
+        StringBuilder sb = new StringBuilder(n);
+        for(int i = 0; i < n; i++) sb.append(rng.nextInt(10));
+        return sb.toString();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,7 +8,7 @@ spring:
       ddl-auto: validate
   flyway:
     enabled: true
-    locations: classpath:db/migration,classpath:db/seed
+    locations: classpath:db/migration
 
 management:
   endpoints:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,23 @@ server:
 rest:
   ai:
     base-url: http://3.36.109.88:8000
+
+security:
+  otp:
+    pepper: ${OTP_PEPPER}         # 환경변수/Secrets Manager로 주입 (필수)
+    code-length: 6
+    ttl-seconds: 300              # OTP 유효기간 5분
+    token-ttl-seconds: 600        # pre-signup 검증토큰 유효기간 10분
+    resend-min-seconds: 60        # 재발송 쿨다운(초)
+    max-resend-per-hour: 5
+    max-attempts: 5
+
+
+
+logging:
+  charset:
+    console: UTF-8
+    file: UTF-8
+
+
+

--- a/src/main/resources/db/migration/V2__create_email_otp.sql
+++ b/src/main/resources/db/migration/V2__create_email_otp.sql
@@ -1,0 +1,118 @@
+-- V2__create_email_otp.sql
+
+-- 1) email_otp 신규 테이블 (이미 있으면 패스)
+CREATE TABLE IF NOT EXISTS email_otp (
+                                         id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                                         email VARCHAR(255) NOT NULL,
+    code_hash VARCHAR(255) NOT NULL,
+    expires_at DATETIME NOT NULL,
+    verified BIT(1) NOT NULL DEFAULT 0,
+    attempt_count INT NOT NULL DEFAULT 0,
+    last_sent_at DATETIME NOT NULL,
+    resend_count INT NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_email_otp_email (email),
+    INDEX idx_email_otp_expires (expires_at),
+    INDEX idx_email_otp_pending (email, verified, expires_at)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 2) email_verification_token 컬럼 보강 (IF NOT EXISTS 미사용: 동적 SQL로 가드)
+
+-- 2-1) created_at 없으면 추가
+SET @col_exists := (
+  SELECT COUNT(*) FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'email_verification_token'
+    AND COLUMN_NAME = 'created_at'
+);
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE email_verification_token ADD COLUMN created_at DATETIME NULL',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- 2-2) updated_at 없으면 추가
+SET @col_exists := (
+  SELECT COUNT(*) FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'email_verification_token'
+    AND COLUMN_NAME = 'updated_at'
+);
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE email_verification_token ADD COLUMN updated_at DATETIME NULL',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- 2-3) 타임스탬프 디폴트/ON UPDATE 표준화
+ALTER TABLE email_verification_token
+    MODIFY COLUMN created_at DATETIME NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE email_verification_token
+    MODIFY COLUMN updated_at DATETIME NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+-- 3) pre-signup 지원 확장
+
+-- 3-1) user_id NULL 허용
+ALTER TABLE email_verification_token
+    MODIFY COLUMN user_id BIGINT NULL;
+
+-- 3-2) email / pre_signup (없으면 추가)
+-- email
+SET @col_exists := (
+  SELECT COUNT(*) FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'email_verification_token'
+    AND COLUMN_NAME = 'email'
+);
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE email_verification_token ADD COLUMN email VARCHAR(255) NULL',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- pre_signup
+SET @col_exists := (
+  SELECT COUNT(*) FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'email_verification_token'
+    AND COLUMN_NAME = 'pre_signup'
+);
+SET @sql := IF(@col_exists = 0,
+  'ALTER TABLE email_verification_token ADD COLUMN pre_signup BIT(1) NOT NULL DEFAULT 1',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- 3-3) 인덱스들 (없으면 생성)
+-- idx_evt_email
+SET @idx_exists := (
+  SELECT COUNT(*) FROM information_schema.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'email_verification_token'
+    AND INDEX_NAME = 'idx_evt_email'
+);
+SET @sql := IF(@idx_exists = 0,
+  'CREATE INDEX idx_evt_email ON email_verification_token (email)',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- idx_evt_exp
+SET @idx_exists := (
+  SELECT COUNT(*) FROM information_schema.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'email_verification_token'
+    AND INDEX_NAME = 'idx_evt_exp'
+);
+SET @sql := IF(@idx_exists = 0,
+  'CREATE INDEX idx_evt_exp ON email_verification_token (expires_at)',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- uq_evt_token (토큰 유니크)
+SET @idx_exists := (
+  SELECT COUNT(*) FROM information_schema.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'email_verification_token'
+    AND INDEX_NAME = 'uq_evt_token'
+);
+SET @sql := IF(@idx_exists = 0,
+  'CREATE UNIQUE INDEX uq_evt_token ON email_verification_token (token)',
+  'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;


### PR DESCRIPTION

- 가입 전에 이메일을 검증하고, 검증 증거를 토큰으로 제출하도록 변경 (기존 VerifyEmailToken 재사용)

## 핵심 변경 사항
- OTP 발송/검증 API: 
  - POST /auth/email/otp/request
  - POST /auth/email/otp/verify (검증 성공 시 verificationToken 발급)
- 회원가입:
  - POST /auth/signup: verificationToken 제출 시 즉시 ACTIVE 생성 (PENDING 없음)
- 스키마(Flyway V2): email_otp 신설, email_verification_token 확장(user_id NULL, email/pre_signup/used, 타임스탬프 기본값/인덱스/UNIQUE)

## 코드 구성
- DTO/Entity/Repository/Service/Controller 반영
- 보안: OTP 해시(SHA-256+pepper), 상수시간 비교, 레이트 제한
- 검증토큰: 짧은 TTL + 1회용(원자적 소진)

## 테스트
1) /auth/email/otp/request
2) /auth/email/otp/verify → verificationToken 확인
3) /auth/signup (verificationToken 포함)
