### PR TITLE
refactor: entity created_at, updated_at 통일

### DIFF
--- a/src/main/java/com/example/final_projects/entity/Category.java
+++ b/src/main/java/com/example/final_projects/entity/Category.java
@@ -30,6 +30,6 @@ public class Category {
     @Column(name = "is_active")
     private Boolean isActive = true;
 
-    @Column(name = "created_at")
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/final_projects/entity/EmailOtp.java
+++ b/src/main/java/com/example/final_projects/entity/EmailOtp.java
@@ -36,13 +36,11 @@ public class EmailOtp {
     @Column(name="resend_count", nullable=false)
     private int resendCount = 0;
 
-    @Column(name="created_at", nullable=false)
-    private LocalDateTime createdAt = LocalDateTime.now();
+    @Column(name="created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
 
-    @Column(name="updated_at", nullable=false)
-    private LocalDateTime updatedAt = LocalDateTime.now();
-
-    @PreUpdate public void onUpdate() {this.updatedAt = LocalDateTime.now();}
+    @Column(name="updated_at", updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime updatedAt;
 
     public String getEmail() {
         return email;

--- a/src/main/java/com/example/final_projects/entity/Industry.java
+++ b/src/main/java/com/example/final_projects/entity/Industry.java
@@ -22,6 +22,7 @@ public class Industry {
 
     private String name;
 
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 
     @ManyToMany(mappedBy = "industries")

--- a/src/main/java/com/example/final_projects/entity/PasswordResetToken.java
+++ b/src/main/java/com/example/final_projects/entity/PasswordResetToken.java
@@ -21,6 +21,9 @@ public class PasswordResetToken {
     @Column(nullable=false)
     private boolean used = false;
 
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/example/final_projects/entity/Purpose.java
+++ b/src/main/java/com/example/final_projects/entity/Purpose.java
@@ -22,6 +22,7 @@ public class Purpose {
 
     private String name;
 
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 
     @ManyToMany(mappedBy = "purposes")

--- a/src/main/java/com/example/final_projects/entity/Template.java
+++ b/src/main/java/com/example/final_projects/entity/Template.java
@@ -1,6 +1,5 @@
 package com.example.final_projects.entity;
 
-import com.example.final_projects.dto.template.AiTemplateResponse;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -56,7 +55,10 @@ public class Template {
     @Column(name = "reject_reason_summary", length = 500)
     private String rejectReasonSummary;
 
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
     private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "template", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -88,26 +90,4 @@ public class Template {
     )
     @Builder.Default
     private Set<Purpose> purposes = new HashSet<>();
-
-    @PrePersist
-    public void prePersist() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    @PreUpdate
-    public void preUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    public void updateFromAi(AiTemplateResponse ai) {
-        this.categoryId = ai.categoryId();
-        this.title = ai.title();
-        this.content = ai.content();
-        this.imageUrl = ai.imageUrl();
-        this.type = TemplateType.valueOf(ai.type());
-        this.isPublic = ai.isPublic();
-        this.status = TemplateStatus.valueOf(ai.status());
-        this.updatedAt = ai.updatedAt();
-    }
 }

--- a/src/main/java/com/example/final_projects/entity/TemplateButton.java
+++ b/src/main/java/com/example/final_projects/entity/TemplateButton.java
@@ -35,5 +35,6 @@ public class TemplateButton {
     @Column(name = "link_ios", length = 500)
     private String linkIos;
 
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/final_projects/entity/TemplateHistory.java
+++ b/src/main/java/com/example/final_projects/entity/TemplateHistory.java
@@ -25,5 +25,6 @@ public class TemplateHistory {
     @Enumerated(EnumType.STRING)
     private TemplateStatus status;
 
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/final_projects/entity/TemplateIndustry.java
+++ b/src/main/java/com/example/final_projects/entity/TemplateIndustry.java
@@ -25,5 +25,6 @@ public class TemplateIndustry {
     @JoinColumn(name = "template_id", nullable = false)
     private Template template;
 
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/final_projects/entity/TemplatePurpose.java
+++ b/src/main/java/com/example/final_projects/entity/TemplatePurpose.java
@@ -25,5 +25,6 @@ public class TemplatePurpose {
     @JoinColumn(name = "template_id", nullable = false)
     private Template template;
 
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/final_projects/entity/TemplateVariable.java
+++ b/src/main/java/com/example/final_projects/entity/TemplateVariable.java
@@ -31,5 +31,6 @@ public class TemplateVariable {
     @Column(name = "input_type", length = 50)
     private String inputType;
 
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/final_projects/entity/User.java
+++ b/src/main/java/com/example/final_projects/entity/User.java
@@ -1,8 +1,6 @@
 package com.example.final_projects.entity;
 
 import jakarta.persistence.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -43,12 +41,10 @@ public class User {
             inverseJoinColumns=@JoinColumn(name="role_id"))
     private Set<Role> roles = new HashSet<>();
 
-    @CreatedDate
-    @Column(nullable = false, updatable=false)
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 
-    @LastModifiedDate
-    @Column(nullable=false)
+    @Column(name = "updated_at", updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
     private LocalDateTime updatedAt;
 
     public User() {
@@ -67,7 +63,7 @@ public class User {
         return this.id != null && this.id.equals(other.id);
     }
 
-    public User(Long id, String email, String passwordHash, String name, Status status, boolean locked, LocalDateTime lockedAt, LocalDateTime lastLoginAt, int failCount, Set<Role> roles, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public User(Long id, String email, String passwordHash, String name, Status status, boolean locked, LocalDateTime lockedAt, LocalDateTime lastLoginAt, int failCount, Set<Role> roles) {
         this.id = id;
         this.email = email;
         this.passwordHash = passwordHash;
@@ -78,8 +74,6 @@ public class User {
         this.lastLoginAt = lastLoginAt;
         this.failCount = failCount;
         this.roles = roles;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
     }
 
     @Override
@@ -125,14 +119,6 @@ public class User {
 
     public Set<Role> getRoles() {
         return roles;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
-
-    public LocalDateTime getUpdatedAt() {
-        return updatedAt;
     }
 
     public void setEmail(String email) {

--- a/src/main/java/com/example/final_projects/entity/UserTemplateRequest.java
+++ b/src/main/java/com/example/final_projects/entity/UserTemplateRequest.java
@@ -2,6 +2,7 @@ package com.example.final_projects.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -29,28 +30,18 @@ public class UserTemplateRequest {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
+    @ColumnDefault("'PENDING'")
     private UserTemplateRequestStatus status;
 
-    @Column(name = "error_message", length = 500)
-    private String errorMessage;
-
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
     private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "userTemplateRequest", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Template> templates = new ArrayList<>();
 
-    @PrePersist
-    public void prePersist() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
-        if (this.status == null) {
-            this.status = UserTemplateRequestStatus.PENDING;
-        }
-    }
-
-    @PreUpdate
-    public void preUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
+    @OneToMany(mappedBy = "userTemplateRequest", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserTemplateRequestLog> logs;
 }

--- a/src/main/java/com/example/final_projects/entity/VerifyEmailToken.java
+++ b/src/main/java/com/example/final_projects/entity/VerifyEmailToken.java
@@ -31,12 +31,10 @@ public class VerifyEmailToken {
     @Column(nullable=false)
     private boolean preSignup = true;
 
-    @Generated(GenerationTime.INSERT) // 선택: 하이버네이트에게 DB가 채운다고 힌트
-    @Column(name="created_at", insertable = false, updatable = false)  // ★ 핵심
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 
-    @Generated(GenerationTime.ALWAYS) // 선택
-    @Column(name="updated_at", insertable = false, updatable = false)  // ★ 핵심
+    @Column(name = "updated_at", updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
     private LocalDateTime updatedAt;
 
     public VerifyEmailToken() {


### PR DESCRIPTION
## refactor: entity created_at, updated_at 관리 방식 통일

### ✅ PR 종류
- [ ] feat (새로운 기능 추가)  
- [ ] fix (버그 수정)  
- [X] refactor (코드 리팩토링)  
- [ ] docs (문서 추가 및 수정)  
- [ ] style (비즈니스 로직 영향 없는 변경)  
- [ ] test (테스트 코드 관련 작업)  
- [ ] chore (빌드/설정 등 기타 변경)  

### 📝 작업 내용
- `created_at`, `updated_at` 관리 방식을 **DB 레벨**로 통일
- 엔티티에서 `@PrePersist`, `@PreUpdate`, `LocalDateTime.now()` 등의 애플리케이션 레벨 처리 제거  
- JPA 엔티티 필드 수정:
```java
@Column(name = "created_at", nullable = false, updatable = false, insertable = false,
        columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
private LocalDateTime createdAt;

@Column(name = "updated_at", insertable = false, updatable = false,
        columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
private LocalDateTime updatedAt;
```
* Flyway 스크립트에서 created_at, updated_at 컬럼을 ```TIMESTAMP DEFAULT CURRENT_TIMESTAMP``` / ```ON UPDATE CURRENT_TIMESTAMP```로 변경
* 엔티티 생성자에서 createdAt, updatedAt 필드 제거

### 🔍 변경 이유
* 관리 방식 후보군 검토:
  * DB 자동 관리: 로그성 데이터 관리에 적합, 코드 단순화, DB가 자동으로 값 갱신
  * Spring Auditing: 테스트 및 모킹 용이, DB와 싱크 필요
* 이번 created_at, updated_at은 로그 성격이 강하고 비즈니스 로직에서 직접 사용되지 않음 → DB 레벨 자동 관리 방식 선택

### 📌 고민했던 점
* 애플리케이션 단에서 값을 세팅할지, DB 단에서 자동 관리할지
* 비즈니스 로직에서 날짜가 사용되는 경우는 애플리케이션 단으로 처리해야 하지만, 로그/추적 용도는 DB에서 관리하는 것이 적합

### 📸 스크린샷 (선택)
* N/A

### ✅ 체크리스트
- [X]  created_at, updated_at DB 레벨 관리로 통일
- [X]  엔티티 필드 수정 및 생성자 정리
- [X] Flyway 스크립트 수정
- [ ] QA 환경 반영 및 검증
- [ ] 리뷰 반영
