### PR TITLE
feat(auth,db): RT 해시 저장 전환 + 스키마 정리(VARCHAR64, issued_at)

### DIFF
--- a/src/main/java/com/example/final_projects/controller/AuthTokenController.java
+++ b/src/main/java/com/example/final_projects/controller/AuthTokenController.java
@@ -1,0 +1,30 @@
+package com.example.final_projects.controller;
+
+import com.example.final_projects.dto.auth.RefreshTokenDtos.RefreshResponse;
+import com.example.final_projects.dto.auth.RefreshTokenDtos.RefreshRequest;
+import com.example.final_projects.service.TokenService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.sql.Ref;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthTokenController {
+
+    private final TokenService tokenService;
+
+    public AuthTokenController(TokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    @PostMapping("/token/refresh")
+    public ResponseEntity<RefreshResponse> refresh(@RequestBody RefreshRequest req) {
+        RefreshResponse res = tokenService.refresh(req.getRefreshToken());
+        return ResponseEntity.ok(res);
+    }
+}
+

--- a/src/main/java/com/example/final_projects/dto/auth/RefreshTokenDtos.java
+++ b/src/main/java/com/example/final_projects/dto/auth/RefreshTokenDtos.java
@@ -1,0 +1,30 @@
+package com.example.final_projects.dto.auth;
+
+public class RefreshTokenDtos {
+    public static class RefreshRequest{
+        private String refreshToken;
+        public RefreshRequest(){}
+        public RefreshRequest(String refreshToken){
+            this.refreshToken = refreshToken;
+        }
+        public String getRefreshToken() {return refreshToken;}
+        public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
+    }
+
+    public static class RefreshResponse{
+        private String accessToken;
+        private String refreshToken;
+        private long accessTokenExpiresInMs;
+        private long refreshTokenExpiresInMs;
+        public RefreshResponse(){}
+        public RefreshResponse(String at, String rt, long atExp, long rtExp){
+            this.accessToken = at; this.refreshToken = rt;
+            this.accessTokenExpiresInMs = atExp; this.refreshTokenExpiresInMs = rtExp;
+        }
+        public String getAccessToken() { return accessToken; }
+        public String getRefreshToken() { return refreshToken; }
+        public long getAccessTokenExpiresInMs() { return accessTokenExpiresInMs; }
+        public long getRefreshTokenExpiresInMs() { return refreshTokenExpiresInMs; }
+
+    }
+}

--- a/src/main/java/com/example/final_projects/entity/RefreshToken.java
+++ b/src/main/java/com/example/final_projects/entity/RefreshToken.java
@@ -6,76 +6,69 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name="refresh_tokens")
+@Table(name="refresh_tokens",
+       indexes = {
+            @Index(name = "idx_refresh_tokens_jti", columnList = "jti"),
+            @Index(name = "idx_refresh_tokens_replaced_by", columnList = "replaced_by_jti"),
+            @Index(name = "idx_refresh_tokens_revoked", columnList = "revoked")
+       },
+        uniqueConstraints = {
+            @UniqueConstraint(name = "uq_refresh_tokens_token_hash", columnNames = "token_hash")
+        })
 public class RefreshToken {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "refresh_token" ,nullable=false, unique=true, length=300)
-    private String token;
+    @Column(name = "token_hash" , length=64)
+    private String tokenHash;
 
-    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name="user_id", nullable=false)
-    private User user;
+    @Column(name="user_id", nullable = false)
+    private Long userId;
 
-    @CreationTimestamp
-    @Column(name="issued_at", nullable=false, updatable=false)
-    private LocalDateTime issuedAt;
+    @Column(name="jti", length = 64)
+    private String jti;
+
+    @Column(name="replaced_by_jti", length = 64)
+    private String replacedByJti;
+
+    @Column(name="rotated_at")
+    private LocalDateTime rotatedAt;
 
     @Column(nullable=false)
     private LocalDateTime expiresAt;
 
+    @Column(name="created_at", insertable=false, updatable=false)
+    private LocalDateTime createdAt;
+
+    @Column(name="updated_at", insertable=false, updatable=false)
+    private LocalDateTime updatedAt;
+
     @Column(nullable=false)
     private boolean revoked =false;
 
-    public LocalDateTime getIssuedAt() {
-        return issuedAt;
-    }
+    public Long getId() { return id; }
+    public Long getUserId() { return userId; }
+    public void setUserId(Long userId) { this.userId = userId; }
 
-    public RefreshToken() {
+    public String getTokenHash() { return tokenHash; }
+    public void setTokenHash(String tokenHash) { this.tokenHash = tokenHash; }
 
-    }
+    public String getJti() { return jti; }
+    public void setJti(String jti) { this.jti = jti; }
 
-    public String getToken() {
-        return token;
-    }
+    public String getReplacedByJti() { return replacedByJti; }
+    public void setReplacedByJti(String replacedByJti) { this.replacedByJti = replacedByJti; }
 
-    public User getUser() {
-        return user;
-    }
+    public boolean isRevoked() { return revoked; }
+    public void setRevoked(boolean revoked) { this.revoked = revoked; }
 
-    public LocalDateTime getExpiresAt() {
-        return expiresAt;
-    }
+    public LocalDateTime getExpiresAt() { return expiresAt; }
+    public void setExpiresAt(LocalDateTime expiresAt) { this.expiresAt = expiresAt; }
 
-    public boolean isRevoked() {
-        return revoked;
-    }
+    public LocalDateTime getRotatedAt() { return rotatedAt; }
+    public void setRotatedAt(LocalDateTime rotatedAt) { this.rotatedAt = rotatedAt; }
 
-    public RefreshToken(LocalDateTime issuedAt) {
-        this.issuedAt = issuedAt;
-    }
-
-    public RefreshToken(Long id, String token, User user, LocalDateTime expiresAt, boolean revoked) {
-        this.id = id;
-        this.token = token;
-        this.user = user;
-        this.expiresAt = expiresAt;
-        this.revoked = revoked;
-    }
-
-    public void setToken(String token) {
-        this.token = token;
-    }
-
-    public void setUser(User user) {
-        this.user = user;
-    }
-
-    public void setExpiresAt(LocalDateTime expiresAt) {
-        this.expiresAt = expiresAt;
-    }
-
-    public void setRevoked(boolean revoked) {
-        this.revoked = revoked;
-    }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
 }
+

--- a/src/main/java/com/example/final_projects/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/final_projects/security/JwtTokenProvider.java
@@ -9,6 +9,7 @@ import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 @Component
 public class JwtTokenProvider {
@@ -18,14 +19,15 @@ public class JwtTokenProvider {
 
     public JwtTokenProvider(
             @Value("${jwt.secret}") String secret,
-            @Value("${jwt.access-validaity-ms:1800000}") long accessValidityMills,
+            @Value("${jwt.access-validity-ms:1800000}") long accessValidityMillis,   // ✅ 오타 수정
             @Value("${jwt.refresh-validity-ms:1209600000}") long refreshValidityMillis
     ){
         this.key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret));
-        this.accessValidityMillis = accessValidityMills;
+        this.accessValidityMillis = accessValidityMillis;
         this.refreshValidityMillis = refreshValidityMillis;
     }
 
+    // ===== Access Token =====
     public String createAccessToken(Long userId, String email, List<String> roles){
         Date now = new Date();
         Date exp = new Date(now.getTime() + accessValidityMillis);
@@ -37,17 +39,36 @@ public class JwtTokenProvider {
                 .signWith(key, SignatureAlgorithm.HS256).compact();
     }
 
+    public long getAccessValidityMillis() {
+        return accessValidityMillis;
+    }
+
+    // ===== Refresh Token =====
+    /** 기존 메서드(호환): 내부에서 JTI 생성해 위임 */
     public String createRefreshToken(Long userId){
+        return createRefreshToken(userId, UUID.randomUUID().toString());
+    }
+
+    /** ✅ 새 오버로드: 외부에서 만든 JTI를 그대로 사용 (회전 로직과 일치) */
+    public String createRefreshToken(Long userId, String jti){
         Date now = new Date();
         Date exp = new Date(now.getTime() + refreshValidityMillis);
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
+                .setId(jti)   // ★ JWT 표준 jti 클레임
                 .setIssuedAt(now).setExpiration(exp)
                 .signWith(key, SignatureAlgorithm.HS256).compact();
     }
+
+    public long getRefreshValidityMillis() {
+        return refreshValidityMillis;
+    }
+
+    // ===== Parse / Helpers =====
     public Jws<Claims> parse(String token){
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
     }
+
     public Long getUserId(String token){
         return Long.valueOf(parse(token).getBody().getSubject());
     }
@@ -67,6 +88,5 @@ public class JwtTokenProvider {
         } catch (ExpiredJwtException e){
             return true;
         }
-
     }
 }

--- a/src/main/java/com/example/final_projects/security/TokenHashUtil.java
+++ b/src/main/java/com/example/final_projects/security/TokenHashUtil.java
@@ -1,0 +1,20 @@
+package com.example.final_projects.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public final class TokenHashUtil {
+    private TokenHashUtil() {}
+    public static String sha256HexWithPepper(String pepper, String token){
+        try{
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = md.digest((pepper + token).getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(bytes.length * 2);
+            for(byte b : bytes) sb.append(String.format("%02x", b));
+            return sb.toString();
+        } catch(NoSuchAlgorithmException e){
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/src/main/java/com/example/final_projects/service/TokenService.java
+++ b/src/main/java/com/example/final_projects/service/TokenService.java
@@ -1,0 +1,8 @@
+package com.example.final_projects.service;
+
+import com.example.final_projects.dto.auth.RefreshTokenDtos.RefreshResponse;
+
+
+public interface TokenService {
+   RefreshResponse refresh(String refreshToken);
+}

--- a/src/main/java/com/example/final_projects/service/TokenServiceImpl.java
+++ b/src/main/java/com/example/final_projects/service/TokenServiceImpl.java
@@ -1,0 +1,80 @@
+package com.example.final_projects.service;
+
+import com.example.final_projects.dto.auth.RefreshTokenDtos.RefreshResponse;
+import com.example.final_projects.entity.RefreshToken;
+import com.example.final_projects.repository.RefreshTokenRepository;
+import com.example.final_projects.security.JwtTokenProvider;
+import com.example.final_projects.security.TokenHashUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Transactional
+public class TokenServiceImpl implements TokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final String pepper;
+    private final long refreshValidityMs;
+
+    public TokenServiceImpl(RefreshTokenRepository refreshTokenRepository,
+                            JwtTokenProvider jwtTokenProvider,
+                            @Value("${security.refresh.pepper}") String pepper,
+                            @Value("${security.refresh.validity-ms:1209600000}") long refreshValidityMs) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.pepper = pepper;
+        this.refreshValidityMs = refreshValidityMs;
+    }
+
+    @Override
+    public RefreshResponse refresh(String refreshTokenRaw) {
+        // 1) 제출된 RT 해시화 → 조회
+        String hash = TokenHashUtil.sha256HexWithPepper(pepper, refreshTokenRaw);
+        RefreshToken current = refreshTokenRepository.findByTokenHash(hash)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid refresh token"));
+
+        // 2) 재사용/만료 차단
+        if (current.isRevoked() || current.getReplacedByJti() != null) {
+            throw new IllegalStateException("Refresh token reuse detected");
+        }
+        if (current.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("Refresh token expired");
+        }
+
+        // 3) 조건부 회전(동시성 제어)
+        String newJti = UUID.randomUUID().toString();
+        int updated = refreshTokenRepository.markRotated(current.getJti(), newJti);
+        if (updated != 1) {
+            throw new IllegalStateException("Refresh token reuse detected");
+        }
+
+        // 4) 새 AT/RT 발급
+        Long userId = current.getUserId();
+        String accessToken = jwtTokenProvider.createAccessToken(userId, null, List.of("ROLE_USER"));
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId, newJti);
+
+        // 5) 새 RT 저장(해시만 저장)
+        String newHash = TokenHashUtil.sha256HexWithPepper(pepper, newRefreshToken);
+        LocalDateTime newExp = LocalDateTime.now().plus(Duration.ofMillis(refreshValidityMs));
+
+        RefreshToken next = new RefreshToken();
+        next.setUserId(userId);
+        next.setJti(newJti);
+        next.setTokenHash(newHash);
+        next.setExpiresAt(newExp);
+        next.setRevoked(false);
+        refreshTokenRepository.save(next);
+
+        // 6) 응답
+        long atExpMs = jwtTokenProvider.getAccessValidityMillis();
+        long rtExpMs = refreshValidityMs;
+        return new RefreshResponse(accessToken, newRefreshToken, atExpMs, rtExpMs);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,7 +50,9 @@ security:
     max-resend-per-hour: 5
     max-attempts: 5
 
-
+  refresh:
+    pepper: ${REFRESH_PEPPER:change-me-in-secrets}
+    validity-ms: 1209600000   # 14일 (예시)
 
 logging:
   charset:

--- a/src/main/resources/db/migration/V3__rt_rotation_minimal.sql
+++ b/src/main/resources/db/migration/V3__rt_rotation_minimal.sql
@@ -1,0 +1,186 @@
+SET @db := DATABASE();
+
+/* =======================
+   0) Legacy cleanup
+   ======================= */
+-- 평문 refresh_token 컬럼이 있으면 제거
+SET @exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND COLUMN_NAME='refresh_token'
+);
+SET @sql := IF(@exists=1,
+  'ALTER TABLE refresh_tokens DROP COLUMN refresh_token',
+  'DO 0'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+
+/* =======================
+   1) Columns (ensure shape)
+   ======================= */
+
+-- token_hash: VARCHAR(64) NOT NULL (Hibernate 기대 타입)
+SET @dt := NULL; SET @len := NULL;
+SELECT DATA_TYPE, CHARACTER_MAXIMUM_LENGTH
+INTO @dt, @len
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND COLUMN_NAME='token_hash'
+    LIMIT 1;
+SET @sql := IF(
+  @dt IS NULL,
+  'ALTER TABLE refresh_tokens ADD COLUMN token_hash VARCHAR(64) NOT NULL COMMENT ''SHA-256(pepper) of raw refresh token''',
+  IF(LOWER(@dt)='varchar' AND IFNULL(@len,0)=64,
+     'DO 0',
+     'ALTER TABLE refresh_tokens MODIFY COLUMN token_hash VARCHAR(64) NOT NULL COMMENT ''SHA-256(pepper) of raw refresh token'''
+  )
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- jti: VARCHAR(64) NULL (없으면 추가)
+SET @exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND COLUMN_NAME='jti'
+);
+SET @sql := IF(@exists=0,
+  'ALTER TABLE refresh_tokens ADD COLUMN jti VARCHAR(64) NULL COMMENT ''JWT ID of this refresh token''',
+  'DO 0'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- replaced_by_jti: VARCHAR(64) NULL (없으면 추가)
+SET @exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND COLUMN_NAME='replaced_by_jti'
+);
+SET @sql := IF(@exists=0,
+  'ALTER TABLE refresh_tokens ADD COLUMN replaced_by_jti VARCHAR(64) NULL COMMENT ''JTI that replaced this token''',
+  'DO 0'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- revoked: TINYINT(1) NOT NULL DEFAULT 0 (없으면 추가)
+SET @exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND COLUMN_NAME='revoked'
+);
+SET @sql := IF(@exists=0,
+  'ALTER TABLE refresh_tokens ADD COLUMN revoked TINYINT(1) NOT NULL DEFAULT 0 COMMENT ''1=revoked''',
+  'DO 0'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- rotated_at: DATETIME NULL (없으면 추가)
+SET @exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND COLUMN_NAME='rotated_at'
+);
+SET @sql := IF(@exists=0,
+  'ALTER TABLE refresh_tokens ADD COLUMN rotated_at DATETIME NULL COMMENT ''Rotation/replacement time''',
+  'DO 0'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- expires_at: DATETIME NOT NULL (없으면 추가)
+SET @exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND COLUMN_NAME='expires_at'
+);
+SET @sql := IF(@exists=0,
+  'ALTER TABLE refresh_tokens ADD COLUMN expires_at DATETIME NOT NULL COMMENT ''Refresh token expiry''',
+  'DO 0'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- issued_at: DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP (DB auto; 없으면 추가, 있으면 보장)
+SET @exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND COLUMN_NAME='issued_at'
+);
+SET @sql := IF(@exists=0,
+  'ALTER TABLE refresh_tokens ADD COLUMN issued_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''Issued time (DB managed)''',
+  'ALTER TABLE refresh_tokens MODIFY COLUMN issued_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''Issued time (DB managed)'''
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- created_at: DATETIME NULL DEFAULT CURRENT_TIMESTAMP (없으면 추가)
+SET @exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND COLUMN_NAME='created_at'
+);
+SET @sql := IF(@exists=0,
+  'ALTER TABLE refresh_tokens ADD COLUMN created_at DATETIME NULL DEFAULT CURRENT_TIMESTAMP COMMENT ''Row creation time (DB managed)''',
+  'DO 0'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- updated_at: DATETIME NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP (없으면 추가)
+SET @exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND COLUMN_NAME='updated_at'
+);
+SET @sql := IF(@exists=0,
+  'ALTER TABLE refresh_tokens ADD COLUMN updated_at DATETIME NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT ''Row update time (DB managed)''',
+  'DO 0'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+
+/* =======================
+   2) Indexes / Constraints
+   ======================= */
+
+-- (선택) token_hash HEX 체크(64자리 소문자) - MySQL 8.0.16+
+SET @has_chk := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens'
+    AND CONSTRAINT_TYPE='CHECK' AND CONSTRAINT_NAME='chk_token_hash_hex'
+);
+SET @sql := IF(@has_chk=0,
+  'ALTER TABLE refresh_tokens ADD CONSTRAINT chk_token_hash_hex CHECK (token_hash REGEXP ''^[0-9a-f]{64}$'')',
+  'DO 0'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- UNIQUE(token_hash)
+SET @exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND INDEX_NAME='uq_refresh_tokens_token_hash'
+);
+SET @sql := IF(@exists=0,
+  'CREATE UNIQUE INDEX uq_refresh_tokens_token_hash ON refresh_tokens (token_hash)',
+  'DO 0'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- INDEX(jti)
+SET @exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND INDEX_NAME='idx_refresh_tokens_jti'
+);
+SET @sql := IF(@exists=0,
+  'CREATE INDEX idx_refresh_tokens_jti ON refresh_tokens (jti)',
+  'DO 0'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- INDEX(replaced_by_jti)
+SET @exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND INDEX_NAME='idx_refresh_tokens_replaced_by'
+);
+SET @sql := IF(@exists=0,
+  'CREATE INDEX idx_refresh_tokens_replaced_by ON refresh_tokens (replaced_by_jti)',
+  'DO 0'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- INDEX(revoked)
+SET @exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA=@db AND TABLE_NAME='refresh_tokens' AND INDEX_NAME='idx_refresh_tokens_revoked'
+);
+SET @sql := IF(@exists=0,
+  'CREATE INDEX idx_refresh_tokens_revoked ON refresh_tokens (revoked)',
+  'DO 0'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
로그인: refreshToken 해시(token_hash)만 저장(평문 미저장), jti 저장

만료시간: security.refresh.validity-ms 기반 계산

로그아웃: 입력 RT 해시화 후 revoked=true 처리

DB: legacy refresh_token 컬럼 제거

DB: token_hash VARCHAR(64) NOT NULL + UNIQUE, 인덱스(jti, replaced_by_jti, revoked)

DB: issued_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP

DB: created_at/updated_at DEFAULT CURRENT_TIMESTAMP 보장

스키마 검증 이슈 해결: token_hash 타입 CHAR→VARCHAR(64)로 통일

E2E bash: OTP 요청/검증→가입→로그인→회전→재사용 감지 시나리오 추가