### PR TITLE
feat: 템플릿 승인 요청 API

### DIFF
--- a/src/main/java/com/example/final_projects/controller/TemplateController.java
+++ b/src/main/java/com/example/final_projects/controller/TemplateController.java
@@ -3,6 +3,7 @@ package com.example.final_projects.controller;
 import com.example.final_projects.config.swagger.ApiErrorCodeExample;
 import com.example.final_projects.dto.ApiResult;
 import com.example.final_projects.dto.PageResponse;
+import com.example.final_projects.dto.template.TemplateApproveResponse;
 import com.example.final_projects.dto.template.TemplateCreateRequest;
 import com.example.final_projects.dto.template.TemplateResponse;
 import com.example.final_projects.dto.template.TemplateSearchRequest;
@@ -54,6 +55,21 @@ public class TemplateController {
             @RequestBody TemplateCreateRequest templateCreateRequest
     ) {
         TemplateResponse response = templateService.createTemplate(principal.getId(), templateCreateRequest);
+        return ApiResult.ok(response);
+    }
+
+    @Operation(
+            summary = "템플릿 승인 요청",
+            description = "특정 템플릿에 대해 승인 요청을 보낸다."
+    )
+    @ApiErrorCodeExample(TemplateErrorCode.class)
+    @PostMapping("/{id}/approve-request")
+    public ApiResult<TemplateApproveResponse> approveTemplate(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        System.out.println(principal.getId());
+        TemplateApproveResponse response = templateService.approveTemplate(id, principal.getId());
         return ApiResult.ok(response);
     }
 }

--- a/src/main/java/com/example/final_projects/dto/template/TemplateApproveResponse.java
+++ b/src/main/java/com/example/final_projects/dto/template/TemplateApproveResponse.java
@@ -1,0 +1,11 @@
+package com.example.final_projects.dto.template;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TemplateApproveResponse {
+    private Long templateId;
+    private String status;
+}

--- a/src/main/java/com/example/final_projects/exception/code/TemplateErrorCode.java
+++ b/src/main/java/com/example/final_projects/exception/code/TemplateErrorCode.java
@@ -7,7 +7,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum TemplateErrorCode implements BaseErrorCode {
     INVALID_STATUS(HttpStatus.BAD_REQUEST.value(), "잘못된 상태 값입니다"),
-    FORBIDDEN_STATUS(HttpStatus.BAD_REQUEST.value(), "허용되지 않은 상태 값입니다");
+    FORBIDDEN_STATUS(HttpStatus.BAD_REQUEST.value(), "허용되지 않은 상태 값입니다"),
+    TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "템플릿을 찾을 수 없습니다"),
+    ALREADY_APPROVE_REQUESTED(HttpStatus.BAD_REQUEST.value(), "이미 승인 요청된 템플릿입니다"),
+    FORBIDDEN_TEMPLATE(HttpStatus.FORBIDDEN.value(), "권한이 없는 템플릿입니다"),
+    APPROVE_REQUEST_FORBIDDEN(HttpStatus.BAD_REQUEST.value(), "승인 요청 가능한 상태가 아닙니다");
 
     private final ErrorReason errorReason;
 


### PR DESCRIPTION
## feat: 템플릿 승인 요청 API 구현

### ✅ PR 종류

* [x] feat (새로운 기능 추가)
* [ ] fix (버그 수정)
* [ ] refactor (코드 리팩토링)
* [ ] docs (문서 추가 및 수정)
* [ ] style (비즈니스 로직 영향 없는 변경)
* [ ] test (테스트 코드 관련 작업)
* [ ] chore (빌드/설정 등 기타 변경)

### 📝 작업 내용

* `/api/templates/{id}/approve-request` **POST API** 구현
* 템플릿 상태가 `CREATED`인 경우만 승인 요청 가능하도록 로직 적용
* 승인 요청 시 `TemplateStatus.APPROVE_REQUESTED`로 상태 변경
* 승인 요청 시 히스토리(`TemplateHistory`) 기록
* 권한 없는 사용자 접근 → `FORBIDDEN_TEMPLATE` 에러 처리
* 템플릿이 존재하지 않을 경우 → `TEMPLATE_NOT_FOUND` 에러 처리
* 승인 요청 불가 상태일 경우 → `APPROVE_REQUEST_FORBIDDEN` 에러 처리
* 응답 구조 `templateId`와 `status`만 반환 (`ApiResult` 감싸기)

### 🔍 변경 이유

### ✅ 체크리스트

* [x] 승인 요청 API 컨트롤러 구현
* [x] Service 로직 및 상태/권한 검증 적용
* [x] Response DTO 및 ApiResult 구조 반영
* [ ] Swagger 문서 업데이트
* [ ] QA 환경에서 API 동작 검증
