### PR TITLE
chore api경로 /api로 통일 & otp 123456 고정

### DIFF
--- a/src/main/java/com/example/final_projects/controller/AuthController.java
+++ b/src/main/java/com/example/final_projects/controller/AuthController.java
@@ -7,7 +7,7 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 public class AuthController {
     private final AuthService authService;
     public AuthController(AuthService authService){ this.authService=authService; }

--- a/src/main/java/com/example/final_projects/controller/AuthTokenController.java
+++ b/src/main/java/com/example/final_projects/controller/AuthTokenController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.sql.Ref;
 
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 public class AuthTokenController {
 
     private final TokenService tokenService;

--- a/src/main/java/com/example/final_projects/controller/EmailOtpController.java
+++ b/src/main/java/com/example/final_projects/controller/EmailOtpController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/auth/email/otp")
+@RequestMapping("/api/auth/email/otp")
 public class EmailOtpController {
     private final EmailOtpService emailOtpService;
 

--- a/src/main/java/com/example/final_projects/exception/user/UserErrorCode.java
+++ b/src/main/java/com/example/final_projects/exception/user/UserErrorCode.java
@@ -1,0 +1,63 @@
+package com.example.final_projects.exception.user;
+
+import org.springframework.http.HttpStatus;
+
+public enum UserErrorCode {
+
+//회원가입, 이메일
+EMAIL_DUPLICATE(HttpStatus.CONFLICT, "이미 사용중인 이메일입니다."),
+
+EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 필요합니다."),
+
+OTP_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 코드입니다."),
+
+OTP_EXPIRED(HttpStatus.BAD_REQUEST, "인증 코드가 만료되었습니다."),
+
+OTP_COOLDOWN(HttpStatus.TOO_MANY_REQUESTS, "인증 코드 재요청 쿨다운 중입니다."),
+
+//로그인, 인증
+LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
+
+ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "계정이 잠겼습니다."),
+
+USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+
+// 토큰 / RT 로테이션
+TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+
+TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+
+REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 존재하지 않습니다."),
+
+REFRESH_TOKEN_REUSED(HttpStatus.UNAUTHORIZED, "재사용이 감지된 리프레시 토큰입니다."),
+
+REFRESH_TOKEN_ROTATION_FAILED(HttpStatus.UNAUTHORIZED, "리프레시 토큰 로테이션에 실패했습니다."),
+
+//검증/ 기타
+VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "요청 값이 올바르지 않습니다."),
+
+RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다."),
+
+INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+private final HttpStatus status;
+private final String defaultMessage;
+
+UserErrorCode(HttpStatus status, String defaultMessage) {
+    this.status = status;
+    this.defaultMessage = defaultMessage;
+}
+
+public HttpStatus getStatus() {
+    return status;
+}
+
+public String getDefaultMessage() {
+    return defaultMessage;
+}
+public String code() { return "USER." + name();}
+}

--- a/src/main/java/com/example/final_projects/exception/user/UserException.java
+++ b/src/main/java/com/example/final_projects/exception/user/UserException.java
@@ -1,0 +1,32 @@
+package com.example.final_projects.exception.user;
+
+public class UserException extends RuntimeException {
+    private final UserErrorCode errorCode;
+    private final Object details;
+
+    public UserException(UserErrorCode errorCode) {
+        super(errorCode.getDefaultMessage());
+        this.errorCode = errorCode;
+        this.details = null;
+    }
+    public UserException(UserErrorCode errorCode, String message){
+        super(message);
+        this.errorCode = errorCode;
+        this.details = null;
+    }
+    public UserException(UserErrorCode errorCode, String message, Object details){
+        super(message);
+        this.errorCode = errorCode;
+        this.details =details;
+    }
+
+    public UserErrorCode getErrorCode() {
+
+
+        return errorCode;
+    }
+
+    public Object getDetails() {
+        return details;
+    }
+}

--- a/src/main/java/com/example/final_projects/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/final_projects/security/JwtAuthenticationFilter.java
@@ -23,7 +23,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     // ⚠️ 실제 매핑에 따라 "/auth/**" 또는 "/api/auth/**" 로 맞추세요.
     private static final List<String> WHITELIST = List.of(
-            "/auth/**",
+            "/api/auth/**",
             "/actuator/**"
     );
 

--- a/src/main/java/com/example/final_projects/security/UserAccessDeniedHandler.java
+++ b/src/main/java/com/example/final_projects/security/UserAccessDeniedHandler.java
@@ -1,0 +1,30 @@
+package com.example.final_projects.security;
+
+import com.example.final_projects.dto.ApiResult;
+import com.example.final_projects.dto.ErrorResponse;
+import com.example.final_projects.exception.user.UserErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+public class UserAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper om;
+    public UserAccessDeniedHandler(ObjectMapper om) {this.om = om;}
+    @Override
+    public void handle(HttpServletRequest req, HttpServletResponse res,
+                       org.springframework.security.access.AccessDeniedException e) throws IOException {
+        var code = UserErrorCode.ACCESS_DENIED;
+        var body = ApiResult.<Void>builder()
+                .data(null)
+                .error(ErrorResponse.of(code.code(), code.getDefaultMessage()))
+                .build();
+        res.setStatus(code.getStatus().value());
+        res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        res.setCharacterEncoding("UTF-8");
+        om.writeValue(res.getOutputStream(), body);
+    }
+}

--- a/src/main/java/com/example/final_projects/security/UserAuthEntryPoint.java
+++ b/src/main/java/com/example/final_projects/security/UserAuthEntryPoint.java
@@ -1,0 +1,31 @@
+package com.example.final_projects.security;
+
+import com.example.final_projects.dto.ApiResult;
+import com.example.final_projects.dto.ErrorResponse;
+import com.example.final_projects.exception.user.UserErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class UserAuthEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper om;
+    public UserAuthEntryPoint(ObjectMapper om){ this.om = om; }
+
+    @Override
+    public void commence(HttpServletRequest req, HttpServletResponse res,
+                         org.springframework.security.core.AuthenticationException e) throws IOException {
+        var code = UserErrorCode.AUTH_REQUIRED;
+        var body = ApiResult.<Void>builder()
+                .data(null)
+                .error(ErrorResponse.of(code.code(), code.getDefaultMessage()))
+                .build();
+        res.setStatus(code.getStatus().value());
+        res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        res.setCharacterEncoding("UTF-8");
+        om.writeValue(res.getOutputStream(), body);
+    }
+}


### PR DESCRIPTION
 PR 종류
- [ ] feat (새로운 기능 추가)
- [ ] fix (버그 수정)
- [ ] refactor (코드 리팩토링)
- [ ] docs (문서 추가 및 수정)
- [ ] style (비즈니스 로직 영향 없는 변경)
- [ ] test (테스트 코드 관련 작업)
- [x] chore (빌드/설정 등 기타 변경)

📝 작업 내용
- API Base Path 통일: 컨트롤러 베이스를 @RequestMapping("/api/auth")로 일원화
- SecurityConfig: 허용 경로 /auth/** → /api/auth/** 로 변경
- e2e 스크립트: 모든 경로를 /api/auth/**로 업데이트
-  OTP 고정값 123456 적용 

🔍 변경 이유
- 백엔드 엔드포인트를 /api 프리픽스로 통일해 FE·리버스프록시·문서와 일치
- QA 시나리오 단축(메일 열람 없이 고정 OTP로 검증)
- e2e 스크립트와 서버 경로 불일치 이슈 해소

✅ 체크리스트
- [ ] 컨트롤러 경로 /api/auth로 통일
- [ ] SecurityConfig에 /api/auth/** permitAll 반영
- [ ] e2e bash 스크립트 경로 /api/auth/**로 수정
- [ ] DEV/QA에서만 OTP 123456 고정 (prod 비활성)
- [ ] 로컬/QA에서 OTP 요청→검증→회원가입→로그인→RT 회전 테스트
- [ ] FE 환경변수/호출 경로 /api/**로 동기화

🧪 테스트 노트
- OTP 검증 성공/쿨다운/한도 초과
- 회원가입(이메일 중복, 토큰 불일치/만료)
- 로그인 실패/잠금
- RT 회전 및 재사용(401) 감지
