### PR TITLE
Hotfix: 보안 체인 정상화 후 공개/보호 경로 정리 

### DIFF
--- a/src/main/java/com/example/final_projects/config/SecurityConfig.java
+++ b/src/main/java/com/example/final_projects/config/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.example.final_projects.config;
 
 import com.example.final_projects.security.JwtAuthenticationFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,8 +16,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
-import com.example.final_projects.security.UserAuthEntryPoint;
-import com.example.final_projects.security.UserAccessDeniedHandler;
+
 
 import java.time.Duration;
 import java.util.List;
@@ -48,7 +46,14 @@ public class SecurityConfig {
                         // 프리플라이트 전부 허용
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // 공개 경로
-                        .requestMatchers("/api/auth/**", "/actuator/**").permitAll()
+                        .requestMatchers("/api/auth/**", "/actuator/**",  "/", "/index.html", "/favicon.ico").permitAll()
+                        .requestMatchers(
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**"
+                        ).permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
✅ PR 종류
- [x] hotfix (긴급 수정)
- [ ] feat (새로운 기능 추가)
- [ ] fix (버그 수정)
- [ ] refactor (코드 리팩토링)
- [ ] docs (문서 추가 및 수정)
- [ ] style (비즈니스 로직 영향 없는 변경)
- [ ] test (테스트 코드 관련 작업)
- [x] chore (빌드/설정 등 기타 변경)

📝 작업 내용
- SecurityConfig 업데이트
  - 공개 경로 화이트리스트 명시:
    - `OPTIONS /**`
    - `/api/auth/**`
    - `/actuator/**`
    - `/`, `/index.html`, `/favicon.ico`
    - `/swagger-ui.html`, `/swagger-ui/**`, `/v3/api-docs/**`, `/swagger-resources/**`, `/webjars/**`
  - 그 외 경로는 `anyRequest().authenticated()`로 보호
  - `UserAuthEntryPoint`(401), `UserAccessDeniedHandler`(403) 등록 유지
  - `JwtAuthenticationFilter`를 `UsernamePasswordAuthenticationFilter` 앞에 등록 (기존 유지)
  - 글로벌 `CorsFilter` 최상단 등록 유지
- application-dev.yml 조정
  - `jwt.secret` 고정 값 설정(개발 프로필) → 재기동 후에도 토큰 검증 일관성 확보
  - 보안/SQL 트러블슈팅을 위한 로깅 레벨 상향 (`org.springframework.security`, `org.hibernate.SQL`, `BasicBinder` 등)
  - actuator 노출 범위 확장(health, info, mappings, env, configprops) — dev 한정
- 동작 확인
  - 익명으로 보호 API 접근 시 401 `USER.AUTH_REQUIRED`
  - Swagger UI 및 actuator/루트 정상 접근(200)
  - 유효 토큰으로 보호 API 접근 시 애플리케이션 로직으로 진입 (검증 실패 시 4xx, 내부 오류 시 5xx)

🔍 변경 이유
- AllowAllSecurity 제거 이후, 기본적으로 전체가 인증 요구 상태가 되어 Swagger/루트 접근도 401이 발생
- 개발 생산성을 위해 Swagger/헬스체크/정적 루트·프리플라이트는 공개, 나머지는 보호로 명확히 분리
- dev 환경에서 재기동 시 JWT 시크릿이 흔들리지 않도록 고정해 `INVALID_TOKEN` 발생을 방지

✅ 체크리스트
- [x] SecurityConfig: 공개/보호 경로 설정 적용
- [x] SecurityConfig: EntryPoint/DeniedHandler/JWT 필터 정상 등록
- [x] 익명으로 보호 API → 401 확인
- [x] Swagger/actuator/루트/프리플라이트 → 200 확인
- [ ] QA 점검: 로그인 → 보호 API 200, 검증 실패 시 400, 권한 부족 시 403

🧪 재현/검증 방법
```bash
BASE="http://127.0.0.1:8080"
EMAIL="e2e_user@example.com"
PASS="P@ssw0rd!123"

# 0) dev 프로필 기동 확인 (Active profiles: dev)

# 1) 공개 경로 확인 (200)
curl -i "$BASE/swagger-ui/index.html"
curl -i "$BASE/actuator/health"
curl -i "$BASE/"

# 2) 보호 API: 익명 접근 → 401
curl -i -X GET "$BASE/api/templates"

# 3) 로그인 → accessToken 추출
BODY="$(curl -sS -X POST "$BASE/api/auth/login" \
  -H "Content-Type: application/json; charset=UTF-8" \
  --data-binary "{\"email\":\"$EMAIL\",\"password\":\"$PASS\"}")"
ACCESS="$(printf "%s" "$BODY" | sed -n 's/.*"accessToken"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
ACCESS="$(printf "%s" "$ACCESS" | tr -d '\r\n\"' | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')"

# 4) 보호 API: 토큰 포함 → 애플리케이션 로직 진입 (200 또는 도메인 4xx/5xx)
curl -i -H "Authorization: Bearer $ACCESS" "$BASE/api/templates"