### PR TITLE
hotfix: GitHub Actions deploy.yml 수정 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,31 +1,65 @@
-- name: Restart application on EC2
-  uses: appleboy/ssh-action@v0.1.6
-  with:
-    host: ${{ secrets.EC2_HOST }}
-    username: ubuntu
-    key: ${{ secrets.EC2_SSH_KEY }}
-    script: |
-      chmod +x /home/ubuntu/scripts/*.sh
+name: CI/CD Spring Boot JAR to EC2
 
-      # ===== 환경변수 세팅 (앱이 이 값들을 사용) =====
-      export DB_URL="${{ secrets.DB_URL }}"
-      export DB_USER="${{ secrets.DB_USER }}"
-      export DB_PASS="${{ secrets.DB_PASS }}"
-      export JWT_SECRET="${{ secrets.JWT_SECRET }}"
-      export OTP_PEPPER="${{ secrets.OTP_PEPPER }}"
-      export REFRESH_PEPPER="${{ secrets.REFRESH_PEPPER }}"
-      export VERIFY_BASE_URL="${{ secrets.VERIFY_BASE_URL }}"
-      export AI_BASE_URL="${{ secrets.AI_BASE_URL }}"
+on:
+  push:
+    branches: ["main", "chore/github-actions-pipeline"]
 
-      # 보안/쿠키/CORS/CSRF (추가)
-      export CORS_ALLOWED_ORIGINS="${{ secrets.CORS_ALLOWED_ORIGINS }}"
-      export APP_COOKIE_SAMESITE="${{ secrets.APP_COOKIE_SAMESITE }}"   # Lax/None/Strict
-      export APP_COOKIE_SECURE="${{ secrets.APP_COOKIE_SECURE }}"       # "true"/"false"
-      export APP_COOKIE_MAX_AGE="${{ secrets.APP_COOKIE_MAX_AGE }}"     # 1209600 등
-      export APP_COOKIE_PATH="${{ secrets.APP_COOKIE_PATH }}"           # /api/auth 권장
-      export CSRF_ENABLED="${{ secrets.CSRF_ENABLED }}"                 # "true"/"false"
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
 
-      # ===== 앱 재시작 =====
-      /home/ubuntu/scripts/stop.sh
-      sleep 3
-      /home/ubuntu/scripts/start.sh
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Build with Maven
+        run: mvn clean package -DskipTests
+
+      - name: Upload JAR to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "target/*.jar,scripts/*"
+          target: "/home/ubuntu/"
+
+      - name: Restart application on EC2
+        uses: appleboy/ssh-action@v0.1.6
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            chmod +x /home/ubuntu/scripts/*.sh
+
+            # ===== 환경변수 세팅 =====
+            export DB_URL="${{ secrets.DB_URL }}"
+            export DB_USER="${{ secrets.DB_USER }}"
+            export DB_PASS="${{ secrets.DB_PASS }}"
+            export JWT_SECRET="${{ secrets.JWT_SECRET }}"
+            export OTP_PEPPER="${{ secrets.OTP_PEPPER }}"
+            export REFRESH_PEPPER="${{ secrets.REFRESH_PEPPER }}"
+            export VERIFY_BASE_URL="${{ secrets.VERIFY_BASE_URL }}"
+            export AI_BASE_URL="${{ secrets.AI_BASE_URL }}"
+
+            # 보안/쿠키/CORS/CSRF
+            export CORS_ALLOWED_ORIGINS="${{ secrets.CORS_ALLOWED_ORIGINS }}"
+            export APP_COOKIE_SAMESITE="${{ secrets.APP_COOKIE_SAMESITE }}"   # Lax/None/Strict
+            export APP_COOKIE_SECURE="${{ secrets.APP_COOKIE_SECURE }}"       # "true"/"false"
+            export APP_COOKIE_MAX_AGE="${{ secrets.APP_COOKIE_MAX_AGE }}"     # 1209600 등
+            export APP_COOKIE_PATH="${{ secrets.APP_COOKIE_PATH }}"           # /api/auth 권장
+            export CSRF_ENABLED="${{ secrets.CSRF_ENABLED }}"                 # "true"/"false"
+
+            # ===== 앱 재시작 =====
+            /home/ubuntu/scripts/stop.sh || true
+            sleep 3
+            /home/ubuntu/scripts/start.sh


### PR DESCRIPTION
## 🔥 변경 유형
- [x] hotfix (긴급 수정)
- [ ] fix (버그 수정)
- [ ] refactor (리팩토링)
- [ ] chore (설정/빌드)
- [ ] docs (문서)
- [ ] test (테스트)

## 📌 요약
- GitHub Actions `.github/workflows/deploy.yml`의 YAML/구조 오류를 수정

## ✨ 변경 내용
- [x] 최상위 YAML을 매핑 구조로 유지(`name`/`on`/`jobs`/`steps`)하고, 재시작 스텝은 `jobs.build-and-deploy.steps` 하위에 배치


## ✅ 테스트/검증
- [x] 워크플로 문법 검사 (Actions → `View workflow file` 렌더 확인)
- [x] dry-run성 커밋으로 파이프라인 트리거 (빌드 → 업로드 → 재시작 로그 확인)
- [x] 서버에서 `stop.sh` 미존재/이미 중지 상태 케이스에서 `|| true` 동작 확인
- [x] `start.sh` 실행 후 애플리케이션 헬스체크 OK (예: `/actuator/health` 또는 서비스 엔드포인트 수동 확인)

## 🧯 리스크 / 롤백 플랜
- 서비스 기동 실패 시:
  - [ ] EC2에서 `journalctl -u <서비스명> -e` 또는 `nohup.out` 확인
  - [ ] 수동 롤백: 이전 JAR로 `start.sh` 실행
  - [ ] 필요 시 이 PR revert

## 📎 기타 메모
- systemd로 기동 중이라면 SSH 세션의 `export`는 서비스에 전달되지 않습니다.  
  → `/etc/systemd/system/<서비스>.service`에 `Environment=` 또는 `EnvironmentFile=` 사용 필요.
- CORS/쿠키/CSRF 관련 시크릿이 비어 있으면 앱 부팅 중 예외가 날 수 있으니 저장소 Secrets 상태 점검 권장.

## 👀 체크리스트
- [x] `.github/workflows/deploy.yml` 최상단에 `- name:` 등 시퀀스 시작 없음
- [x] 모든 들여쓰기 스페이스(탭 금지), 파일 EOL = LF


## 🔗 관련 이슈/로그
- YAML 오류: `(Line: 1, Col: 1): A sequence was not expected`
