### PR TITLE
fix(ci): 재시작 스텝 분리로 액션 137(SIGKILL) 실패 방지

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
                   source: "target/*.jar,scripts/*"
                   target: "/home/ubuntu/"
 
-            # CRLF → LF, 실행권한, JAR 존재 체크 (준비 단계)
+            # 준비(줄바꿈/권한/JAR 확인) — 안전
             - name: Prepare scripts on EC2
               uses: appleboy/ssh-action@v0.1.6
               with:
@@ -43,7 +43,7 @@ jobs:
                       chmod +x /home/ubuntu/scripts/*.sh
                       ls -al /home/ubuntu/target/*.jar
 
-            # stop.sh만 별도 실행 (세션 끊겨도 파이프라인은 진행)
+            # stop — 세션 끊겨도 통과
             - name: Stop application on EC2 (allow disconnect)
               uses: appleboy/ssh-action@v0.1.6
               continue-on-error: true
@@ -54,36 +54,41 @@ jobs:
                   script: |
                       /home/ubuntu/scripts/stop.sh || true
 
-            # start.sh 실행 + 환경변수 주입 + 헬스 확인
+            # start — 이 스텝에는 오직 start.sh만! (jober-app 들어간 명령 금지)
             - name: Start application on EC2
+              uses: appleboy/ssh-action@v0.1.6
+              env:
+                  DB_URL: ${{ secrets.DB_URL }}
+                  DB_USER: ${{ secrets.DB_USER }}
+                  DB_PASS: ${{ secrets.DB_PASS }}
+                  JWT_SECRET: ${{ secrets.JWT_SECRET }}
+                  OTP_PEPPER: ${{ secrets.OTP_PEPPER }}
+                  REFRESH_PEPPER: ${{ secrets.REFRESH_PEPPER }}
+                  VERIFY_BASE_URL: ${{ secrets.VERIFY_BASE_URL }}
+                  AI_BASE_URL: ${{ secrets.AI_BASE_URL }}
+                  CORS_ALLOWED_ORIGINS: ${{ secrets.CORS_ALLOWED_ORIGINS }}
+                  APP_COOKIE_SAMESITE: ${{ secrets.APP_COOKIE_SAMESITE }}
+                  APP_COOKIE_SECURE: ${{ secrets.APP_COOKIE_SECURE }}
+                  APP_COOKIE_MAX_AGE: ${{ secrets.APP_COOKIE_MAX_AGE }}
+                  APP_COOKIE_PATH: ${{ secrets.APP_COOKIE_PATH }}
+                  CSRF_ENABLED: ${{ secrets.CSRF_ENABLED }}
+              with:
+                  host: ${{ secrets.EC2_HOST }}
+                  username: ubuntu
+                  key: ${{ secrets.EC2_SSH_KEY }}
+                  envs: DB_URL,DB_USER,DB_PASS,JWT_SECRET,OTP_PEPPER,REFRESH_PEPPER,VERIFY_BASE_URL,AI_BASE_URL,CORS_ALLOWED_ORIGINS,APP_COOKIE_SAMESITE,APP_COOKIE_SECURE,APP_COOKIE_MAX_AGE,APP_COOKIE_PATH,CSRF_ENABLED
+                  script: |
+                      set -euo pipefail
+                      /home/ubuntu/scripts/start.sh
+
+            # health — 이제 별도 세션이므로 'jober-app' 문자열 써도 안전
+            - name: Health check on EC2
               uses: appleboy/ssh-action@v0.1.6
               with:
                   host: ${{ secrets.EC2_HOST }}
                   username: ubuntu
                   key: ${{ secrets.EC2_SSH_KEY }}
                   script: |
-                      set -euo pipefail
-                      
-                      # ===== 환경변수 세팅 (Actions Secrets → 프로세스 환경) =====
-                      export DB_URL='${{ secrets.DB_URL }}'
-                      export DB_USER='${{ secrets.DB_USER }}'
-                      export DB_PASS='${{ secrets.DB_PASS }}'
-                      export JWT_SECRET='${{ secrets.JWT_SECRET }}'
-                      export OTP_PEPPER='${{ secrets.OTP_PEPPER }}'
-                      export REFRESH_PEPPER='${{ secrets.REFRESH_PEPPER }}'
-                      export VERIFY_BASE_URL='${{ secrets.VERIFY_BASE_URL }}'
-                      export AI_BASE_URL='${{ secrets.AI_BASE_URL }}'
-                      
-                      export CORS_ALLOWED_ORIGINS='${{ secrets.CORS_ALLOWED_ORIGINS }}'
-                      export APP_COOKIE_SAMESITE='${{ secrets.APP_COOKIE_SAMESITE }}'
-                      export APP_COOKIE_SECURE='${{ secrets.APP_COOKIE_SECURE }}'
-                      export APP_COOKIE_MAX_AGE='${{ secrets.APP_COOKIE_MAX_AGE }}'
-                      export APP_COOKIE_PATH='${{ secrets.APP_COOKIE_PATH }}'
-                      export CSRF_ENABLED='${{ secrets.CSRF_ENABLED }}'
-                      
-                      /home/ubuntu/scripts/start.sh
-                      
-                      # 간단 헬스 체크
                       sleep 2
                       ss -ltnp | grep :8080 || true
                       tail -n 150 /home/ubuntu/jober-app.log || true


### PR DESCRIPTION
-이유
start.sh 스텝 본문에 jober-app 문자열이 포함되면서 pgrep -f가 부모 셸까지 매치 ⇒ SSH 세션 KILL ⇒ GitHub Actions 137 실패.


-무엇을 했는지
deploy.yml 재시작 과정을 Prepare → Stop(continue-on-error) → Start → Health 4스텝으로 분리
Start 스텝에는 /home/ubuntu/scripts/start.sh만 실행(동 스텝 내 jober-app 문자열 제거)
환경변수는 env/envs로 안전 전달, Health는 별도 스텝에서 수행
start.sh/stop.sh 내용 변경 없음