### PR TITLE
fix(ci): Start 스텝에서 JAVA_TOOL_OPTIONS로 JWT/Refresh 주입 + 헬스 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,30 +58,37 @@ jobs:
             - name: Start application on EC2
               uses: appleboy/ssh-action@v0.1.6
               env:
-                  DB_URL: ${{ secrets.DB_URL }}
-                  DB_USER: ${{ secrets.DB_USER }}
-                  DB_PASS: ${{ secrets.DB_PASS }}
-                  JWT_SECRET: ${{ secrets.JWT_SECRET }}
-                  OTP_PEPPER: ${{ secrets.OTP_PEPPER }}
-                  REFRESH_PEPPER: ${{ secrets.REFRESH_PEPPER }}
-                  VERIFY_BASE_URL: ${{ secrets.VERIFY_BASE_URL }}
-                  AI_BASE_URL: ${{ secrets.AI_BASE_URL }}
-                  CORS_ALLOWED_ORIGINS: ${{ secrets.CORS_ALLOWED_ORIGINS }}
-                  APP_COOKIE_SAMESITE: ${{ secrets.APP_COOKIE_SAMESITE }}
-                  APP_COOKIE_SECURE: ${{ secrets.APP_COOKIE_SECURE }}
-                  APP_COOKIE_MAX_AGE: ${{ secrets.APP_COOKIE_MAX_AGE }}
-                  APP_COOKIE_PATH: ${{ secrets.APP_COOKIE_PATH }}
-                  CSRF_ENABLED: ${{ secrets.CSRF_ENABLED }}
+                DB_URL: ${{ secrets.DB_URL }}
+                DB_USER: ${{ secrets.DB_USER }}
+                DB_PASS: ${{ secrets.DB_PASS }}
+                JWT_SECRET: ${{ secrets.JWT_SECRET }}
+                REFRESH_PEPPER: ${{ secrets.REFRESH_PEPPER }}
+                OTP_PEPPER: ${{ secrets.OTP_PEPPER }}
+                VERIFY_BASE_URL: ${{ secrets.VERIFY_BASE_URL }}
+                AI_BASE_URL: ${{ secrets.AI_BASE_URL }}
+                CORS_ALLOWED_ORIGINS: ${{ secrets.CORS_ALLOWED_ORIGINS }}
+                APP_COOKIE_SAMESITE: ${{ secrets.APP_COOKIE_SAMESITE }}
+                APP_COOKIE_SECURE: ${{ secrets.APP_COOKIE_SECURE }}
+                APP_COOKIE_MAX_AGE: ${{ secrets.APP_COOKIE_MAX_AGE }}
+                APP_COOKIE_PATH: ${{ secrets.APP_COOKIE_PATH }}
+                CSRF_ENABLED: ${{ secrets.CSRF_ENABLED }}
+                # ★ JVM 시스템 프로퍼티로 강제 주입
+                JAVA_TOOL_OPTIONS: "-Djwt.secret=${{ secrets.JWT_SECRET }} -Dsecurity.refresh.pepper=${{ secrets.REFRESH_PEPPER }}"
               with:
-                  host: ${{ secrets.EC2_HOST }}
-                  username: ubuntu
-                  key: ${{ secrets.EC2_SSH_KEY }}
-                  envs: DB_URL,DB_USER,DB_PASS,JWT_SECRET,OTP_PEPPER,REFRESH_PEPPER,VERIFY_BASE_URL,AI_BASE_URL,CORS_ALLOWED_ORIGINS,APP_COOKIE_SAMESITE,APP_COOKIE_SECURE,APP_COOKIE_MAX_AGE,APP_COOKIE_PATH,CSRF_ENABLED
-                  script: |
-                      set -euo pipefail
-                      /home/ubuntu/scripts/start.sh
+                host: ${{ secrets.EC2_HOST }}
+                username: ubuntu
+                key: ${{ secrets.EC2_SSH_KEY }}
+                envs: DB_URL,DB_USER,DB_PASS,JWT_SECRET,REFRESH_PEPPER,OTP_PEPPER,VERIFY_BASE_URL,AI_BASE_URL,CORS_ALLOWED_ORIGINS,APP_COOKIE_SAMESITE,APP_COOKIE_SECURE,APP_COOKIE_MAX_AGE,APP_COOKIE_PATH,CSRF_ENABLED,JAVA_TOOL_OPTIONS
+              script: |
+                set -euo pipefail
+                # 값 유무만 확인(값은 출력 안 함)
+                [ -n "${JWT_SECRET:-}" ] || { echo "JWT_SECRET missing"; exit 1; }
+                [ -n "${REFRESH_PEPPER:-}" ] || { echo "REFRESH_PEPPER missing"; exit 1; }
 
-            # health — 이제 별도 세션이므로 'jober-app' 문자열 써도 안전
+                /home/ubuntu/scripts/start.sh
+          
+
+          # health — 이제 별도 세션이므로 'jober-app' 문자열 써도 안전
             - name: Health check on EC2 (dynamic port)
               uses: appleboy/ssh-action@v0.1.6
               with:


### PR DESCRIPTION
## 왜
- EC2에서 `jwt.secret is missing`로 부팅 실패 → env 전달 불안정 케이스 대비 필요

## 무엇을 변경
- Start 스텝에 `JAVA_TOOL_OPTIONS`로 `-Djwt.secret` / `-Dsecurity.refresh.pepper` 강제 주입
- 재시작 플로우를 **Prepare → Stop(continue-on-error) → Start → Health** 로 분리
- `start.sh`/`stop.sh` 내용 변경 없음

## 체크리스트
- [ ] GitHub Actions 성공
- [ ] EC2에서 프로세스 확인: `ps -ef | grep "spring.application.name=jober-app"`
- [ ] 포트 리슨 확인: `ss -ltnp | grep java` 또는 `lsof -nP -iTCP -sTCP:LISTEN | grep java`
- [ ] 헬스 체크 `GET /actuator/health`가 200/`UP`
- [ ] `/home/ubuntu/jober-app.log`에 `ERROR`/`Exception` 없음
- [ ] Secrets: `JWT_SECRET` Base64 디코드 길이 ≥ 32B (`echo -n "$JWT_SECRET" | base64 -d | wc -c`)
- [ ] Secrets 끝 공백/개행 없음

## 롤백
- [ ] 문제 시 `deploy.yml` 이전 버전으로 되돌림 (revert)
